### PR TITLE
BUGFIX: Fix main navigation on homepage

### DIFF
--- a/Resources/Private/Content/Sites.xml
+++ b/Resources/Private/Content/Sites.xml
@@ -196,6 +196,20 @@
       </variant>
      </node>
     </node>
+    <node identifier="e35d8910-9798-4c30-8759-b3b88d30f8b5" nodeName="home">
+     <variant sortingIndex="200" workspace="live" nodeType="TYPO3.Neos:Shortcut" version="9" removed="" hidden="" hiddenInIndex="">
+      <dimensions>
+       <language>en_US</language>
+      </dimensions>
+      <accessRoles __type="array"/>
+      <creationDateTime __type="object" __classname="DateTime">2016-05-03T14:03:10+02:00</creationDateTime>
+      <lastModificationDateTime __type="object" __classname="DateTime">2016-05-03T14:03:10+02:00</lastModificationDateTime>
+      <properties>
+       <title __type="string">Home</title>
+       <targetMode __type="string">parentNode</targetMode>
+      </properties>
+     </variant>
+    </node>
     <node identifier="a3474e1d-dd60-4a84-82b1-18d2f21891a3" nodeName="features">
      <variant sortingIndex="400" workspace="live" nodeType="TYPO3.Neos.NodeTypes:Page" version="9" removed="" hidden="" hiddenInIndex="">
       <dimensions>
@@ -204,21 +218,6 @@
       <accessRoles __type="array"/>
       <creationDateTime __type="object" __classname="DateTime">2015-04-26T19:43:10+02:00</creationDateTime>
       <lastModificationDateTime __type="object" __classname="DateTime">2015-12-21T22:21:22+01:00</lastModificationDateTime>
-      <properties>
-       <title __type="string">Features</title>
-       <layout __type="string">landingPage</layout>
-       <subpageLayout __type="string">default</subpageLayout>
-       <uriPathSegment __type="string">features</uriPathSegment>
-      </properties>
-     </variant>
-     <variant sortingIndex="400" workspace="live" nodeType="TYPO3.Neos.NodeTypes:Page" version="6" removed="" hidden="" hiddenInIndex="">
-      <dimensions>
-       <language>nl</language>
-      </dimensions>
-      <accessRoles __type="array"/>
-      <creationDateTime __type="object" __classname="DateTime">2015-07-31T18:53:31+02:00</creationDateTime>
-      <lastModificationDateTime __type="object" __classname="DateTime">2015-12-21T22:21:22+01:00</lastModificationDateTime>
-      <lastPublicationDateTime __type="object" __classname="DateTime">2015-07-31T18:55:50+02:00</lastPublicationDateTime>
       <properties>
        <title __type="string">Features</title>
        <layout __type="string">landingPage</layout>

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -42,7 +42,6 @@ page = Page {
 		parts {
 			mainMenu = Menu {
 				templatePath = 'resource://Neos.Demo/Private/Templates/TypoScriptObjects/MainMenu.html'
-				itemCollection = ${q(site).add(q(site).children('[instanceof TYPO3.Neos:Document]')).get()}
 			}
 
 			secondLevelMenu = Menu {


### PR DESCRIPTION
We used Typoscript to add the homepage node to the `ItemCollection`
of the main navigation.
Because the homepage node is one level above the 1st level of document nodes,
this had the side effect that the corresponding menu item had all the
1st-level-pages as sub elements.
On wide screens we solved that by hiding the children of that node, but on
mobile devices it led to duplication like:

* Home
* Features
* Try Me
* ...
* Features
* Try me

This change solves this by introducing a shortcut node "Home"