### PR TITLE
BUGFIX: Set "uriPathSegment" in Homepage-Shortcut

### DIFF
--- a/Resources/Private/Content/Sites.xml
+++ b/Resources/Private/Content/Sites.xml
@@ -207,6 +207,7 @@
       <properties>
        <title __type="string">Home</title>
        <targetMode __type="string">parentNode</targetMode>
+       <uriPathSegment __type="string">home</uriPathSegment>
       </properties>
      </variant>
     </node>


### PR DESCRIPTION
This is a fix for a bug introduced with #7 that led to a broken NodeTree in the Neos Backend.

Background:

Shortcut nodes usually don't need an "uriPathSegment" property because they can't be linked to. However, in the Neos Backend Shortcut nodes *can* be navigated to.