### PR TITLE
BUGFIX: Change ``Inject`` usage for settings

### DIFF
--- a/Classes/Neos/Demo/Controller/FlickrController.php
+++ b/Classes/Neos/Demo/Controller/FlickrController.php
@@ -20,13 +20,13 @@ use TYPO3\Flow\Mvc\Controller\ActionController;
 class FlickrController extends ActionController
 {
     /**
-     * @Flow\Inject(setting="flickr.tagStreamUriPattern")
+     * @Flow\InjectConfiguration(path="flickr.tagStreamUriPattern")
      * @var string
      */
     protected $tagStreamUriPattern;
 
     /**
-     * @Flow\Inject(setting="flickr.userStreamUriPattern")
+     * @Flow\InjectConfiguration(path="flickr.userStreamUriPattern")
      * @var string
      */
     protected $userStreamUriPattern;


### PR DESCRIPTION
``Inject`` together with settings is deprecated in favor of the
``InjectConfiguration`` annotation.