### PR TITLE
TASK: Update outdated Swiftmailer package reference in comment

### DIFF
--- a/Resources/Private/Form/contact-form.yaml
+++ b/Resources/Private/Form/contact-form.yaml
@@ -38,7 +38,7 @@ renderables:
           placeholder: 'Your Message'
         defaultValue: ''
 finishers:
-# Uncomment the following lines and install the typo3/swiftmailer package to send mails
+# Uncomment the following lines and install the neos/swiftmailer package to send mails
 #  -
 #    identifier: 'Neos.Form:Email'
 #    options:


### PR DESCRIPTION
The `typo3/swiftmailer` package in the comment on line 41 is outdated, it
is changed it to `neos/swiftmailer` instead.