### PR TITLE
TASK: Remove fusion-namespaces from Neos.Demo

### DIFF
--- a/Resources/Private/Fusion/NodeTypes/Carousel.fusion
+++ b/Resources/Private/Fusion/NodeTypes/Carousel.fusion
@@ -1,8 +1,8 @@
 ##
 # "Carousel" element
 #
-prototype(Site:Carousel) {
-	carouselItems = ContentCollection {
+prototype(Neos.Demo:Carousel) {
+	carouselItems = Neos.Neos:ContentCollection {
 		nodePath = 'carouselItems'
 		content.iterationName = 'carouselItemsIteration'
 		attributes.class = 'carousel-inner'

--- a/Resources/Private/Fusion/NodeTypes/ChapterMenu.fusion
+++ b/Resources/Private/Fusion/NodeTypes/ChapterMenu.fusion
@@ -1,7 +1,7 @@
 ##
 # "ChapterMenu" element, extending the default "Menu"
 #
-prototype(Site:ChapterMenu) < prototype(Neos.NodeTypes:Menu) {
+prototype(Neos.Demo:ChapterMenu) < prototype(Neos.NodeTypes:Menu) {
 	attributes.class = 'chapter-menu'
 	chapterImageWidth = '100'
 	chapterImageHeight = '100'

--- a/Resources/Private/Fusion/NodeTypes/Flickr.fusion
+++ b/Resources/Private/Fusion/NodeTypes/Flickr.fusion
@@ -1,7 +1,7 @@
 ##
 # "Flickr" element, extending "Plugin"
 #
-prototype(Site:Flickr) < prototype(Neos.Neos:Plugin) {
+prototype(Neos.Demo:Flickr) < prototype(Neos.Neos:Plugin) {
 	package = 'Neos.Demo'
 	controller = 'Flickr'
 	action = 'tagStream'

--- a/Resources/Private/Fusion/NodeTypes/Registration.fusion
+++ b/Resources/Private/Fusion/NodeTypes/Registration.fusion
@@ -1,7 +1,7 @@
 ##
 # "Registration" element, extending "Plugin"
 #
-prototype(Site:Registration) < prototype(Plugin) {
+prototype(Neos.Demo:Registration) < prototype(Neos.Neos:Plugin) {
 	package = 'Neos.Demo'
 	controller = 'Registration'
 }

--- a/Resources/Private/Fusion/NodeTypes/YouTube.fusion
+++ b/Resources/Private/Fusion/NodeTypes/YouTube.fusion
@@ -1,6 +1,6 @@
 ##
 # "YouTube" element
 #
-prototype(Site:YouTube) < prototype(Content) {
+prototype(Neos.Demo:YouTube) < prototype(Neos.Neos:Content) {
 	attributes.class = 'responsive-video'
 }

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,15 +1,9 @@
-##
-# Create shorthand namespace for our site package name.
-# It is available in all included fusion files.
-#
-namespace: Site=Neos.Demo
-
 include: NodeTypes/*
 
 /**
  * Root Fusion template for the Neos demo website
  */
-page = Page {
+page = Neos.Neos:Page {
 	head {
 		stylesheets {
 			site = Neos.Fusion:Template {
@@ -40,24 +34,24 @@ page = Page {
 		imageTitleText = ${q(node).property('imageTitleText')}
 
 		parts {
-			mainMenu = Menu {
+			mainMenu = Neos.Neos:Menu {
 				templatePath = 'resource://Neos.Demo/Private/Templates/FusionObjects/MainMenu.html'
 			}
 
-			secondLevelMenu = Menu {
+			secondLevelMenu = Neos.Neos:Menu {
 				entryLevel = 2
 				templatePath = 'resource://Neos.Demo/Private/Templates/FusionObjects/SecondLevelMenu.html'
 				maximumLevels = 1
 			}
 
-			metaMenu = Menu {
+			metaMenu = Neos.Neos:Menu {
 				entryLevel = 2
 				templatePath = 'resource://Neos.Demo/Private/Templates/FusionObjects/MetaMenu.html'
 				maximumLevels = 1
 				startingPoint = ${q(site).children('metamenu').get(0)}
 			}
 
-			breadcrumb = BreadcrumbMenu
+			breadcrumb = Neos.Neos:BreadcrumbMenu
 
 			languageMenu = Neos.Neos:DimensionMenu {
 				dimension = 'language'
@@ -66,18 +60,18 @@ page = Page {
 		}
 
 		content {
-			teaser = ContentCollection {
+			teaser = Neos.Neos:ContentCollection {
 				nodePath = 'teaser'
 			}
 
 			// Default content section
-			main = PrimaryContent {
+			main = Neos.Neos:PrimaryContent {
 				nodePath = 'main'
 			}
 		}
 
 		// A shared footer which can be edited from all pages
-		footer = ContentCollection {
+		footer = Neos.Neos:ContentCollection {
 			nodePath = ${q(site).children('footer').property('_path')}
 			collection = ${q(site).children('footer').children()}
 		}
@@ -106,7 +100,7 @@ chapter {
 	body {
 		templatePath = 'resource://Neos.Demo/Private/Templates/Page/Chapter.html'
 		title = ${q(node).property('title')}
-		title.@process.convertUris = ConvertUris
+		title.@process.convertUris = Neos.Neos:ConvertUris
 
 		// Get the previous chapter by traversing to the node which preceds the current one.
 		// We need to specify the nodetype because there could be other node types like content collections on the same level.


### PR DESCRIPTION
The namespaces are a source of confusion and using them in
Neos.Demo encourages too many people to use them and run
into confusion.

In addition we are planning to remove the definition of the default
fusion namespace and the transfer of namespaces to includes and
this is part of the preparation for that.