### PR TITLE
BUGFIX: Workaround of old UI breaks new UI

### DIFF
--- a/Resources/Private/Styles/_Navigation.scss
+++ b/Resources/Private/Styles/_Navigation.scss
@@ -20,7 +20,7 @@
 	}
 
 	// Fix for menu position in neos backend
-	.neos-backend:not(.neos-full-screen) & {
+	.neos-controls & {
 		top: 82px;
 		@media #{$screen-sm} {
 			top: auto;


### PR DESCRIPTION
In the old UI a workaround was needed to ensure the content top navigation was positioned correctly, however in the new UI that made it unreachable. This change adjusts the workaround to only apply to the old UI.

Fixes: #36