### PR TITLE
!!!TASK: Change default charset and collation to utf8mb4

### DIFF
--- a/Migrations/Mysql/Version20110824181409.php
+++ b/Migrations/Mysql/Version20110824181409.php
@@ -17,7 +17,7 @@ class Version20110824181409 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("CREATE TABLE typo3_phoenixdemotypo3org_domain_model_registration (flow3_persistence_identifier VARCHAR(40) NOT NULL, username VARCHAR(255) DEFAULT NULL, password VARCHAR(255) DEFAULT NULL, firstname VARCHAR(255) DEFAULT NULL, lastname VARCHAR(255) DEFAULT NULL, PRIMARY KEY(flow3_persistence_identifier)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
+        $this->addSql("CREATE TABLE typo3_phoenixdemotypo3org_domain_model_registration (flow3_persistence_identifier VARCHAR(40) NOT NULL, username VARCHAR(255) DEFAULT NULL, password VARCHAR(255) DEFAULT NULL, firstname VARCHAR(255) DEFAULT NULL, lastname VARCHAR(255) DEFAULT NULL, PRIMARY KEY(flow3_persistence_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB");
     }
 
     /**


### PR DESCRIPTION
This changes the charset and collation to create table statements in the
existing migrations. This make sure the tables are set up correctly
independent of the database default configuration.

Background information on why this is done can be found in
https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434