### PR TITLE
BUGFIX: Add basic document prototype

### DIFF
--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -3,7 +3,7 @@ include: NodeTypes/*
 /**
  * Root Fusion template for the Neos demo website
  */
-page = Neos.Neos:Page {
+prototype(Neos.NodeTypes:Page) < prototype(Neos.Neos:Page) {
 	head {
 		stylesheets {
 			site = Neos.Fusion:Template {
@@ -82,6 +82,8 @@ page = Neos.Neos:Page {
 		}
 	}
 }
+
+page = Neos.NodeTypes:Page
 
 default < page
 


### PR DESCRIPTION
Add basic document prototype for better compliance with the new updates done in the root matcher and the `Neos.NodeTypes` package