### PR TITLE
TASK: Remove obsolete `@children` annotation from afx code

### DIFF
--- a/Resources/Private/Fusion/Content/Carousel.fusion
+++ b/Resources/Private/Fusion/Content/Carousel.fusion
@@ -23,7 +23,7 @@ prototype(Neos.Demo:Content.Carousel) < prototype(Neos.Neos:ContentComponent) {
             <div class="carousel slide" id={props.identifier}>
 
                 <ol class="carousel-indicators">
-                    <Neos.Fusion:Loop items={Array.range(1, props.carouselItemNumber)} itemName="index" iterationName="iterator" @children="itemRenderer" >
+                    <Neos.Fusion:Loop items={Array.range(1, props.carouselItemNumber)} itemName="index" iterationName="iterator">
                         <li
                             data-target={'#' + props.identifier}
                             data-slide-to={iterator.index}

--- a/Resources/Private/Fusion/Content/ChapterMenu.fusion
+++ b/Resources/Private/Fusion/Content/ChapterMenu.fusion
@@ -37,7 +37,7 @@ prototype(Neos.Demo:Content.ChapterMenu) < prototype(Neos.Neos:ContentComponent)
     renderer = afx`
         <div class="chapter-menu">
             <ul>
-                <Neos.Fusion:Loop items={props.chapters} itemName="chapter" @children="itemRenderer">
+                <Neos.Fusion:Loop items={props.chapters} itemName="chapter">
                     <li>
                         <img
                             src={chapter.imageSrc}

--- a/Resources/Private/Fusion/Document/Fragment/Menu/Breadcrumb.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Breadcrumb.fusion
@@ -3,7 +3,7 @@ prototype(Neos.Demo:Document.Fragment.Menu.Breadcrumb) < prototype(Neos.Fusion:C
 
     renderer = afx`
         <ul class="breadcrumb">
-            <Neos.Fusion:Loop items={Array.reverse(props.menuItems)} @children="itemRenderer">
+            <Neos.Fusion:Loop items={Array.reverse(props.menuItems)}>
                 <li class={item.state}>
                     <Neos.Neos:NodeLink node={item.node} >{item.label}</Neos.Neos:NodeLink>
                 </li>

--- a/Resources/Private/Fusion/Document/Fragment/Menu/Language.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Language.fusion
@@ -6,14 +6,14 @@ prototype(Neos.Demo:Document.Fragment.Menu.Language) < prototype(Neos.Fusion:Com
     renderer = afx`
         <div class="language-menu">
             <div>
-                <Neos.Fusion:Loop items={props.menuItems} @children="itemRenderer">
+                <Neos.Fusion:Loop items={props.menuItems}>
                     <span @if.isCurrent={item.state == 'current'} class="language-menu-full">{item.label}</span>
                     <span @if.isCurrent={item.state == 'current'} class="language-menu-short" title="{item.label}">{item.preset.uriSegment}</span>
                 </Neos.Fusion:Loop>
                 <span>▼</span>
             </div>
             <ul>
-                <Neos.Fusion:Loop items={props.menuItems} @children="itemRenderer">
+                <Neos.Fusion:Loop items={props.menuItems}>
                     <li>
                         <Neos.Neos:NodeLink node={item.node}>{item.label}</Neos.Neos:NodeLink>
                     </li>

--- a/Resources/Private/Fusion/Document/Fragment/Menu/Main.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Main.fusion
@@ -35,14 +35,14 @@ prototype(Neos.Demo:Document.Fragment.Menu.Main) < prototype(Neos.Fusion:Compone
 
             <div class="collapse navbar-collapse navbar-main-collapse">
                 <ul class="nav nav-pills nav-justified">
-                    <Neos.Fusion:Loop items={props.menuItems} @children="itemRenderer">
+                    <Neos.Fusion:Loop items={props.menuItems}>
                         <li class={item.state}>
                             <Neos.Neos:NodeLink node={item.node}>{item.label}</Neos.Neos:NodeLink>
                             <ul
                                 @if.has={item.children && (item.state != 'normal')}
                                 class="second-level-sub-navigation nav nav-justified visible-xs"
                             >
-                                <Neos.Fusion:Loop items={item.children} itemName="item" @children="itemRenderer">
+                                <Neos.Fusion:Loop items={item.children} itemName="item">
                                     <li class={item.state}>
                                         <Neos.Neos:NodeLink node={item.node}>{item.label}</Neos.Neos:NodeLink>
                                     </li>

--- a/Resources/Private/Fusion/Document/Fragment/Menu/Meta.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Meta.fusion
@@ -8,7 +8,7 @@ prototype(Neos.Demo:Document.Fragment.Menu.Meta) < prototype(Neos.Fusion:Compone
     renderer = afx`
         <nav @if.hasMenuItems={props.menuItems} class="nav" role="navigation">
             <ul class="nav nav-pills">
-                <Neos.Fusion:Loop items={props.menuItems} @children="itemRenderer">
+                <Neos.Fusion:Loop items={props.menuItems}>
                     <li class={item.state}>
                         <Neos.Neos:NodeLink node={item.node}>{item.label}</Neos.Neos:NodeLink>
                     </li>

--- a/Resources/Private/Fusion/Document/Fragment/Menu/Secondary.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Secondary.fusion
@@ -7,7 +7,7 @@ prototype(Neos.Demo:Document.Fragment.Menu.Secondary) < prototype(Neos.Fusion:Co
     renderer = afx`
         <nav @if.hasMenuItems={props.menuItems} class="navbar second-level-navigation" role="navigation">
             <ul class="nav nav-pills">
-                <Neos.Fusion:Loop items={props.menuItems} @children="itemRenderer">
+                <Neos.Fusion:Loop items={props.menuItems}>
                     <li class={item.state}>
                         <Neos.Neos:NodeLink node={item.node}>{item.label}</Neos.Neos:NodeLink>
                     </li>


### PR DESCRIPTION
With https://github.com/neos/neos-development-collection/pull/2400 the @children annotation is not required for Loops in AFX any more as a fallback to `content` was introduced.  

This change does not alter functionality but improves the readability of the afx code in Neos.Demo.