### PR TITLE
BUGFIX: Correct constraints and make nodeTypes.yaml valid again

### DIFF
--- a/Configuration/NodeTypes.Document.Chapter.yaml
+++ b/Configuration/NodeTypes.Document.Chapter.yaml
@@ -4,6 +4,10 @@
 'Neos.Demo:Document.Chapter':
   superTypes:
     'Neos.Neos:Document': true
+  constraints:
+    nodeTypes:
+      'Neos.Demo:Document.Homepage': false
+      'Neos.Demo:Document.NotFoundPage': false
   childNodes:
     'main':
       type: 'Neos.Demo:Collection.Content.Main'

--- a/Configuration/NodeTypes.Document.NotFoundPage.yaml
+++ b/Configuration/NodeTypes.Document.NotFoundPage.yaml
@@ -8,9 +8,6 @@
     label: i18n
     icon: 'times'
 
-    # hide in node creation dialogue
-    group: ~
-
   # no further sub documents are allowed here
   constraints:
     nodeTypes:

--- a/Configuration/NodeTypes.Document.Page.yaml
+++ b/Configuration/NodeTypes.Document.Page.yaml
@@ -17,7 +17,8 @@
           icon: 'icon-image'
   constraints:
     nodeTypes:
-      'Neos.Demo:Homepage': false
+      'Neos.Demo:Document.Homepage': false
+      'Neos.Demo:Document.NotFoundPage': false
   childNodes:
     'main':
       type: 'Neos.Demo:Collection.Content.Main'


### PR DESCRIPTION
The homepage and not found page are now forbidden via constraints instead of an empty group which caused validation errors.