### PR TITLE
BUGFIX: Restore mobile language menu and do not link non translated items

### DIFF
--- a/Resources/Private/Fusion/Document/Fragment/Menu/Language.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Language.fusion
@@ -8,14 +8,15 @@ prototype(Neos.Demo:Document.Fragment.Menu.Language) < prototype(Neos.Fusion:Com
             <div>
                 <Neos.Fusion:Loop items={props.menuItems}>
                     <span @if.isCurrent={item.state == 'current'} class="language-menu-full">{item.label}</span>
-                    <span @if.isCurrent={item.state == 'current'} class="language-menu-short" title="{item.label}">{item.preset.uriSegment}</span>
+                    <span @if.isCurrent={item.state == 'current'} class="language-menu-short" title={item.label}>{item.label}</span>
                 </Neos.Fusion:Loop>
                 <span>▼</span>
             </div>
             <ul>
                 <Neos.Fusion:Loop items={props.menuItems}>
                     <li>
-                        <Neos.Neos:NodeLink node={item.node}>{item.label}</Neos.Neos:NodeLink>
+                        <Neos.Neos:NodeLink node={item.node} @if.hasNode={item.node}>{item.label}</Neos.Neos:NodeLink>
+                        <span @if.hasNoNode={!item.node}>{item.label}</span>
                     </li>
                 </Neos.Fusion:Loop>
             </ul>

--- a/Resources/Private/Fusion/Document/Fragment/Menu/Language.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Language.fusion
@@ -8,15 +8,21 @@ prototype(Neos.Demo:Document.Fragment.Menu.Language) < prototype(Neos.Fusion:Com
             <div>
                 <Neos.Fusion:Loop items={props.menuItems}>
                     <span @if.isCurrent={item.state == 'current'} class="language-menu-full">{item.label}</span>
-                    <span @if.isCurrent={item.state == 'current'} class="language-menu-short" title={item.label}>{item.label}</span>
+                    <span @if.isCurrent={item.state == 'current'} class="language-menu-short" title={item.label}>{Configuration.setting('Neos.ContentRepository.contentDimensions.language.presets.' + item.targetDimensions.language.value + '.uriSegment')}</span>
                 </Neos.Fusion:Loop>
                 <span>▼</span>
             </div>
             <ul>
                 <Neos.Fusion:Loop items={props.menuItems}>
-                    <li>
-                        <Neos.Neos:NodeLink node={item.node} @if.hasNode={item.node}>{item.label}</Neos.Neos:NodeLink>
-                        <span @if.hasNoNode={!item.node}>{item.label}</span>
+                    <li @if.hasNode={item.node}>
+                        <Neos.Neos:NodeLink node={item.node} >
+                            <span class="language-menu-full">{item.label}</span>
+                            <span class="language-menu-short" title={item.label}>{Configuration.setting('Neos.ContentRepository.contentDimensions.language.presets.' + item.targetDimensions.language.value + '.uriSegment')}</span>
+                        </Neos.Neos:NodeLink>
+                    </li>
+                    <li @if.hasNoNode={!item.node}>
+                        <span class="language-menu-full">{item.label}</span>
+                        <span class="language-menu-short" title={item.label}>{Configuration.setting('Neos.ContentRepository.contentDimensions.language.presets.' + item.targetDimensions.language.value + '.uriSegment')}</span>
                     </li>
                 </Neos.Fusion:Loop>
             </ul>


### PR DESCRIPTION
Now a span is rendered for non translated languages instead of a link.
 
In addition this restores the the rendering of mobile dimensions menu which did 
not work for a while. Problem was the key `preset` was simply not put into the item from
the DimensionMenuItemImplementation since ages. Now the Configuration.setting helper is used instead.