### PR TITLE
BUGFIX: Set document node context for 404 page

### DIFF
--- a/Resources/Private/Fusion/Override/Error.fusion
+++ b/Resources/Private/Fusion/Override/Error.fusion
@@ -9,6 +9,7 @@ error {
         @position = 'start'
         condition = ${statusCode >= 400 && statusCode < 500 && notfoundDocument}
         renderer = Neos.Fusion:Renderer {
+            @context.documentNode = ${notfoundDocument}
             @context.node = ${notfoundDocument}
             renderPath = '/root'
         }


### PR DESCRIPTION
Without this Fusion code that uses `documentNode` will take the context
of the homepage instead.
As many people copy this piece of code it makes sense to fix.