### PR TITLE
BUGFIX: Carousel identifier bugfix

### DIFF
--- a/Resources/Private/Fusion/Content/Carousel.fusion
+++ b/Resources/Private/Fusion/Content/Carousel.fusion
@@ -2,7 +2,7 @@
 # "Carousel" element
 #
 prototype(Neos.Demo:Content.Carousel) < prototype(Neos.Neos:ContentComponent) {
-    identifier = ${q(node).property('_identifier')}
+    identifier = ${'id-' + q(node).property('_identifier')}
 
     carouselItems = Neos.Neos:ContentCollection {
         nodePath = 'carouselitems'


### PR DESCRIPTION
Prepend 'id-' to the identifier that is used for the Bootstrap carousel demo component.
When the node identifier starts with a number the carousel won't slide on previous, next or indicator click, because IDs are not allowed to start with a number.
Feel free to use any other prefix that starts with a letter. This is just a hint that the bug exists.