### PR TITLE
BUGFIX: Fix script tags in document head

### DIFF
--- a/Resources/Private/Fusion/Document/Fragment/JavaScript.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/JavaScript.fusion
@@ -3,8 +3,8 @@
  */
 prototype(Neos.Demo:Document.Fragment.JavaScripts) < prototype(Neos.Fusion:Component) {
     renderer = afx`
-        <script src={StaticResource.uri('Neos.Twitter.Bootstrap', 'Public/Libraries/jQuery/jquery-1.10.1.min.js')} />
-        <script src={StaticResource.uri('Neos.Twitter.Bootstrap', 'Public/3/js/bootstrap.min.js')} />
-        <script src={StaticResource.uri('Neos.Demo', 'Public/Scripts/Main.js')} />
+        <script defer src={StaticResource.uri('Neos.Twitter.Bootstrap', 'Public/Libraries/jQuery/jquery-1.10.1.min.js')}></script>
+        <script defer src={StaticResource.uri('Neos.Twitter.Bootstrap', 'Public/3/js/bootstrap.min.js')}></script>
+        <script defer src={StaticResource.uri('Neos.Demo', 'Public/Scripts/Main.js')}></script>
     `
 }


### PR DESCRIPTION
self closing script tags are not allowed.
this led to the whole inline editing to fail in the Neos backend.
it is a regression that was introduced with #83.
it took us far too long to find the root cause.
we should stabilze the neos backend for those cases.
wtf.

ps: I also re-added the `defer` attributes that got lost with the
    original change