### PR TITLE
BUGFIX: Remove reverse order

### DIFF
--- a/Resources/Private/Fusion/Document/Fragment/Menu/Breadcrumb.fusion
+++ b/Resources/Private/Fusion/Document/Fragment/Menu/Breadcrumb.fusion
@@ -3,7 +3,7 @@ prototype(Neos.Demo:Document.Fragment.Menu.Breadcrumb) < prototype(Neos.Fusion:C
 
     renderer = afx`
         <ul class="breadcrumb">
-            <Neos.Fusion:Loop items={Array.reverse(props.menuItems)}>
+            <Neos.Fusion:Loop items={props.menuItems}>
                 <li class={item.state}>
                     <Neos.Neos:NodeLink node={item.node} >{item.label}</Neos.Neos:NodeLink>
                 </li>


### PR DESCRIPTION
As we fixed the reverse ordering in the fusion prototype `Neos.Neos:BreadcrumbMenuItems` itself, we don't need that anymore.

@see https://github.com/neos/neos-development-collection/issues/3407