### PR TITLE
[BUGFIX] Remove leftover content element from Carousel yaml

### DIFF
--- a/NodeTypes/Content/Carousel.yaml
+++ b/NodeTypes/Content/Carousel.yaml
@@ -22,7 +22,3 @@
         * HTML
         * YouTube
         * References
-
-'Neos.Demo:Content.Carousel.Collection':
-  superTypes:
-    'Neos.Neos:Content': true


### PR DESCRIPTION
It makes no sense anymore and is probably a leftover from a refactory effort long ago, but is electable in the "new content" wizard and results in an exception if choosen.
![neos-wrong-content-element](https://user-images.githubusercontent.com/11320147/166146120-db51c3ab-840a-492b-9e2b-e10183bc0bf8.png)
