### PR TITLE
TASK: Remove icon prefix

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -31,7 +31,7 @@ Neos:
         contentDimensions:
           language:
             label: 'Neos.Demo:Main:contentDimensions.language'
-            icon: icon-language
+            icon: language
             values:
               'en_US':
                 label: English (US)


### PR DESCRIPTION
The "icon-" prefix is not needed anymore. See also: https://github.com/neos/Neos.Demo/blob/8.3/Configuration/Settings.CR.yaml#L6