### PR TITLE
BUGFIX: Fix indention for username validation

### DIFF
--- a/NodeTypes/Content/Registration/Registration.fusion
+++ b/NodeTypes/Content/Registration/Registration.fusion
@@ -26,9 +26,7 @@ prototype(Neos.Demo:Content.Registration) < prototype(Neos.Neos:ContentComponent
             `
 
             schema {
-                username = ${Form.
-
-            Schema.string().isRequired().validator('Neos\Demo\Form\Runtime\Validation\Validator\UsernameInUseValidator')}
+                username = ${Form.Schema.string().isRequired().validator('Neos\Demo\Form\Runtime\Validation\Validator\UsernameInUseValidator')}
                 password = ${Form.Schema.string().isRequired()}
             }
         }


### PR DESCRIPTION
The registration form was broken, caused by the wrong line breaks and indention.

```
Exception #1327682383 in line 65 of /application/Data/Temporary/Development/SubContextBeach/SubContextInstance/Cache/Code/Flow_Object_Classes/Neos_Eel_CompilingEvaluator.php: Expression "Form.            Schema.string().isRequired().validator('Neos\Demo\Form\Runtime\Validation\Validator\UsernameInUseValidator')" could not be parsed. Error starting at character 4: ".            Schema.string().isRequired().validator('Neos\Demo\Form\Runtime\Validation\Validator\UsernameInUseValidator')".
```