### PR TITLE
BUGFIX: remove unneeded defaultValues

### DIFF
--- a/NodeTypes/Content/BlogPostingList/BlogPostingList.yaml
+++ b/NodeTypes/Content/BlogPostingList/BlogPostingList.yaml
@@ -25,7 +25,6 @@
   properties:
     blogs:
       type: references
-      defaultValue: ''
       ui:
         label: i18n
         showInCreationDialog: true

--- a/NodeTypes/Document/Blog/BlogPosting.yaml
+++ b/NodeTypes/Document/Blog/BlogPosting.yaml
@@ -35,7 +35,6 @@
           group: default
     datePublished:
       type: DateTime
-      defaultValue: now
       ui:
         label: i18n
         reloadIfChanged: true


### PR DESCRIPTION
resolves #173 

Also until https://github.com/neos/neos-ui/pull/3392 isn't merged, we should remove the `defaultValue` property from the `blogs` property. Otherwise it always shows `Invalid date` and this isn't very nice for the editor IMO.