### PR TITLE
BUGFIX: allow YoutubeCarousel element only in the Carousel Content Element

### DIFF
--- a/NodeTypes/Collection/Content/Main.yaml
+++ b/NodeTypes/Collection/Content/Main.yaml
@@ -10,3 +10,4 @@
     nodeTypes:
       '*': false
       'Neos.Demo:Constraint.Content.Main': true
+      'Neos.Demo:Content.CarouselYouTube': false

--- a/NodeTypes/Collection/Content/Main.yaml
+++ b/NodeTypes/Collection/Content/Main.yaml
@@ -10,4 +10,4 @@
     nodeTypes:
       '*': false
       'Neos.Demo:Constraint.Content.Main': true
-      'Neos.Demo:Content.CarouselYouTube': false
+      'Neos.Demo:Constraint.Content.Carousel': false


### PR DESCRIPTION
resolves: #180 

It should not be possible to use the Youtube Content Element for the Carousel Slider on the hole page.