### PR TITLE
BUGFIX: Declare dependency on neos/seo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "neos/nodetypes-assetlist": "^8.3",
         "neos/nodetypes-contentreferences": "^8.3",
         "neos/nodetypes-html": "^8.3",
-        "neos/nodetypes-navigation": "^8.3"
+        "neos/nodetypes-navigation": "^8.3",
+        "neos/seo": "~3.0"
     },
     "suggest": {
         "sitegeist/monocle": "An living-styleguide for Neos that is based on the actual fusion-code",


### PR DESCRIPTION
We use Fusion prototypes from Neos.Seo, Fusion fails if these prototypes are not declared, therefore the demo site depends on Neos.Seo.