### PR TITLE
TASK: Use `NodeType -> references` configuration instead of properties of `type: reference/s`

### DIFF
--- a/NodeTypes/Content/BlogPostingList/BlogPostingList.yaml
+++ b/NodeTypes/Content/BlogPostingList/BlogPostingList.yaml
@@ -22,9 +22,8 @@
           label: i18n
           icon: 'newspaper'
           position: 50
-  properties:
+  references:
     blogs:
-      type: references
       ui:
         label: i18n
         showInCreationDialog: true
@@ -33,6 +32,7 @@
           group: 'blog'
           editorOptions:
             nodeTypes: ['Neos.Demo:Document.Blog']
+  properties:
     limit:
       type: integer
       defaultValue: 5

--- a/NodeTypes/Content/ContactForm/ContactForm.yaml
+++ b/NodeTypes/Content/ContactForm/ContactForm.yaml
@@ -24,6 +24,16 @@
           label: i18n
           icon: comment
           tab: default
+  references:
+    redirect:
+      constraints:
+        maxItems: 1
+      ui:
+        label: i18n
+        inspector:
+          group: redirect
+          editorOptions:
+            nodeTyps: [ 'Neos.Neos:Document' ]
   properties:
     subject:
       type: string
@@ -60,15 +70,6 @@
         label: i18n
         inspector:
           group: email
-    redirect:
-      type: reference
-      defaultValue: null
-      ui:
-        label: i18n
-        inspector:
-          group: redirect
-          editorOptions:
-            nodeTyps: ['Neos.Neos:Document']
     message:
       type: string
       defaultValue: ''

--- a/NodeTypes/Document/Homepage/Homepage.yaml
+++ b/NodeTypes/Document/Homepage/Homepage.yaml
@@ -30,9 +30,8 @@
     'footer':
       position: 'end'
       type: 'Neos.Demo:Collection.Content.Footer'
-  properties:
+  references:
     metaNavigationItems:
-      type: references
       ui:
         label: i18n
         inspector:

--- a/NodeTypes/Override/ContentReferences.yaml
+++ b/NodeTypes/Override/ContentReferences.yaml
@@ -2,7 +2,7 @@
   superTypes:
     'Neos.Demo:Constraint.Content.Main': true
     'Neos.Demo:Constraint.Content.Column': true
-  properties:
+  references:
     references:
       ui:
         showInCreationDialog: true

--- a/Resources/Private/Translations/de/NodeTypes/Content/BlogPostingList.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/BlogPostingList.xlf
@@ -10,7 +10,7 @@
         <source>Blog</source>
         <target state="translated">Blog</target>
       </trans-unit>
-      <trans-unit id="properties.blogs" xml:space="preserve">
+      <trans-unit id="references.blogs" xml:space="preserve">
         <source>Blogs</source>
       </trans-unit>
       <trans-unit id="properties.limit" xml:space="preserve">

--- a/Resources/Private/Translations/de/NodeTypes/Content/ContactForm.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/ContactForm.xlf
@@ -22,7 +22,7 @@
         <source>Message after submit</source>
         <target state="translated">Nachricht nach dem Senden</target>
       </trans-unit>
-      <trans-unit id="properties.redirect" xml:space="preserve">
+      <trans-unit id="references.redirect" xml:space="preserve">
         <source>Redirect after submit</source>
         <target state="translated">Weiterleitung nach dem Senden</target>
       </trans-unit>

--- a/Resources/Private/Translations/de/NodeTypes/Document/Homepage.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Document/Homepage.xlf
@@ -13,7 +13,7 @@
       <trans-unit id="tabs.site" xml:space="preserve">
         <source>Site configuration</source>
       </trans-unit>
-      <trans-unit id="properties.metaNavigationItems" xml:space="preserve">
+      <trans-unit id="references.metaNavigationItems" xml:space="preserve">
         <source>Meta navigation items</source>
       </trans-unit>
     </body>

--- a/Resources/Private/Translations/en/NodeTypes/Content/BlogPostingList.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/BlogPostingList.xlf
@@ -9,7 +9,7 @@
             <trans-unit id="groups.blog" xml:space="preserve">
                 <source>Blog</source>
             </trans-unit>
-            <trans-unit id="properties.blogs" xml:space="preserve">
+            <trans-unit id="references.blogs" xml:space="preserve">
                 <source>Blogs</source>
             </trans-unit>
             <trans-unit id="properties.limit" xml:space="preserve">

--- a/Resources/Private/Translations/en/NodeTypes/Content/ContactForm.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/ContactForm.xlf
@@ -17,7 +17,7 @@
             <trans-unit id="properties.message" xml:space="preserve">
 				<source>Message after submit</source>
 			</trans-unit>
-            <trans-unit id="properties.redirect" xml:space="preserve">
+            <trans-unit id="references.redirect" xml:space="preserve">
 				<source>Redirect after submit</source>
 			</trans-unit>
             <trans-unit id="properties.recipientName" xml:space="preserve">

--- a/Resources/Private/Translations/en/NodeTypes/Document/Homepage.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Document/Homepage.xlf
@@ -11,7 +11,7 @@
             <trans-unit id="tabs.site" xml:space="preserve">
 				<source>Site configuration</source>
 			</trans-unit>
-			<trans-unit id="properties.metaNavigationItems" xml:space="preserve">
+			<trans-unit id="references.metaNavigationItems" xml:space="preserve">
 				<source>Meta navigation items</source>
 			</trans-unit>
 		</body>


### PR DESCRIPTION
The properties of `type: reference/s` are now configured via the references as references via properties are deprecated and are converted internally anyways.

**Review instructions**

This is based on: https://github.com/neos/neos-development-collection/pull/5310