### PR TITLE
FEATURE: Introduce blog categories

### DIFF
--- a/NodeTypes/Document/Blog/Blog.yaml
+++ b/NodeTypes/Document/Blog/Blog.yaml
@@ -19,6 +19,8 @@
       'Neos.Demo:Constraint.Document.SubPage': false
       # but BlogPostings are explicitly allowed
       'Neos.Demo:Document.BlogPosting': true
+      # and BlogCategories as well
+      'Neos.Demo:Document.BlogCategory': true
   childNodes:
     'teaser':
       position: 'before main'

--- a/NodeTypes/Document/Blog/BlogCategory.fusion
+++ b/NodeTypes/Document/Blog/BlogCategory.fusion
@@ -1,0 +1,30 @@
+/**
+ * BlogCategory rendering for the Neos.Demo website
+ */
+prototype(Neos.Demo:Document.BlogCategory) < prototype(Neos.Demo:Document.Page) {
+    # content is overwritten to render the intro section first
+    content >
+    content = Neos.Fusion:Join {
+        intro = Neos.Demo:Presentation.BlogIntro {
+            title = Neos.Neos:Editable {
+                property = 'title'
+                block = false
+            }
+            abstract = Neos.Neos:Editable {
+                property = 'abstract'
+                block = false
+            }
+            imageUri = Neos.Neos:ImageUri {
+                asset = ${q(node).property('image')}
+                width = 1248
+                height = 702
+            }
+        }
+        intro.@process.contentElementWrapping = Neos.Neos:ContentElementWrapping
+
+        main = Neos.Neos:ContentCollection {
+            nodePath = 'main'
+            @process.convertUris = Neos.Neos:ConvertUris
+        }
+    }
+}

--- a/NodeTypes/Document/Blog/BlogCategory.fusion
+++ b/NodeTypes/Document/Blog/BlogCategory.fusion
@@ -2,7 +2,7 @@
  * BlogCategory rendering for the Neos.Demo website
  */
 prototype(Neos.Demo:Document.BlogCategory) < prototype(Neos.Demo:Document.Page) {
-    # content is overwritten to render the intro section first
+
     content >
     content = Neos.Fusion:Join {
         intro = Neos.Demo:Presentation.BlogIntro {
@@ -21,6 +21,41 @@ prototype(Neos.Demo:Document.BlogCategory) < prototype(Neos.Demo:Document.Page) 
             }
         }
         intro.@process.contentElementWrapping = Neos.Neos:ContentElementWrapping
+
+        cards = Neos.Demo:Presentation.Cards.Container {
+            content = Neos.Fusion:Loop {
+                items = ${q(documentNode).backReferenceNodes('categories')}
+                items.@process.sortBy = ${value.sort("datePublished", "DESC")}
+
+                itemName = 'blogPosting'
+
+                itemRenderer = Neos.Demo:Presentation.Cards.Card {
+                    imageUri = Neos.Neos:ImageUri {
+                        asset = ${q(blogPosting).property('image')}
+                        maximumWidth = 400
+                        maximumHeight = 225
+                    }
+                    date = ${q(blogPosting).property('datePublished')}
+                    authorName = ${q(blogPosting).property('authorName')}
+                    title = ${q(blogPosting).property('title')}
+                    content = ${q(blogPosting).property('abstract')}
+                    uri = Neos.Neos:NodeUri {
+                        node = ${blogPosting}
+                    }
+                }
+            }
+
+            @cache {
+                mode = "cached"
+                entryIdentifier {
+                    documentNode = ${Neos.Caching.entryIdentifierForNode(documentNode)}
+                }
+                entryTags {
+                    # invalidate cache entry when a blog posting changes as that might be linked
+                    1 = ${Neos.Caching.nodeTypeTag('Neos.Demo:Document.BlogPosting', documentNode)}
+                }
+            }
+        }
 
         main = Neos.Neos:ContentCollection {
             nodePath = 'main'

--- a/NodeTypes/Document/Blog/BlogCategory.yaml
+++ b/NodeTypes/Document/Blog/BlogCategory.yaml
@@ -1,0 +1,32 @@
+'Neos.Demo:Document.BlogCategory':
+  final: true
+  superTypes:
+    'Neos.Demo:Document.Page': true
+    'Neos.Demo:Constraint.Document.SubPage': false
+  ui:
+    label: i18n
+    icon: 'tag'
+    position: 310
+    group: special
+    help:
+      message: i18n
+  constraints:
+    nodeTypes:
+      # No documents below here
+      'Neos.Demo:Constraint.Document.SubPage': false
+  properties:
+    # Hide title field in inspector as this will be inline editable on this page.
+    title:
+      ui:
+        inspector:
+          group: ~
+    abstract:
+      options:
+        preset: 'neosdemo.text.lead'
+    image:
+      type: Neos\Media\Domain\Model\ImageInterface
+      ui:
+        label: i18n
+        reloadIfChanged: true
+        inspector:
+          group: default

--- a/NodeTypes/Document/Blog/BlogPosting.fusion
+++ b/NodeTypes/Document/Blog/BlogPosting.fusion
@@ -45,9 +45,18 @@ prototype(Neos.Demo:Document.BlogPosting) < prototype(Neos.Demo:Document.Page) {
                 width = 1248
                 height = 702
             }
-            metadata = afx`
-                {Date.format(q(node).property('datePublished'), 'd.m.Y')} - {q(node).property('authorName')}
-            `
+            metadata = Neos.Fusion:Join {
+                @glue = ' - '
+                date = ${Date.format(q(node).property('datePublished'), 'd.m.Y')}
+                author = ${q(node).property('authorName')}
+                category = Neos.Fusion:Loop {
+                    @context.categories = ${q(node).referenceNodes('categories').get()}
+                    @if.has = ${categories != []}
+                    @glue = ', '
+                    items = ${categories}
+                    itemRenderer = ${q(item).property('title')}
+                }
+            }
         }
         intro.@process.contentElementWrapping = Neos.Neos:ContentElementWrapping
 

--- a/NodeTypes/Document/Blog/BlogPosting.fusion
+++ b/NodeTypes/Document/Blog/BlogPosting.fusion
@@ -54,7 +54,13 @@ prototype(Neos.Demo:Document.BlogPosting) < prototype(Neos.Demo:Document.Page) {
                     @if.has = ${categories != []}
                     @glue = ', '
                     items = ${categories}
-                    itemRenderer = ${q(item).property('title')}
+                    itemRenderer = Neos.Fusion:Tag {
+                        tagName = 'a'
+                        attributes.href = Neos.Neos:NodeUri {
+                            node = ${item}
+                        }
+                        content = ${q(item).property('title')}
+                    }
                 }
             }
         }

--- a/NodeTypes/Document/Blog/BlogPosting.fusion
+++ b/NodeTypes/Document/Blog/BlogPosting.fusion
@@ -45,8 +45,9 @@ prototype(Neos.Demo:Document.BlogPosting) < prototype(Neos.Demo:Document.Page) {
                 width = 1248
                 height = 702
             }
-            author = ${q(node).property('authorName')}
-            date = ${q(node).property('datePublished')}
+            metadata = afx`
+                {Date.format(q(node).property('datePublished'), 'd.m.Y')} - {q(node).property('authorName')}
+            `
         }
         intro.@process.contentElementWrapping = Neos.Neos:ContentElementWrapping
 

--- a/NodeTypes/Document/Blog/BlogPosting.fusion
+++ b/NodeTypes/Document/Blog/BlogPosting.fusion
@@ -54,12 +54,8 @@ prototype(Neos.Demo:Document.BlogPosting) < prototype(Neos.Demo:Document.Page) {
                     @if.has = ${categories != []}
                     @glue = ', '
                     items = ${categories}
-                    itemRenderer = Neos.Fusion:Tag {
-                        tagName = 'a'
-                        attributes.href = Neos.Neos:NodeUri {
-                            node = ${item}
-                        }
-                        content = ${q(item).property('title')}
+                    itemRenderer = Neos.Neos:NodeLink {
+                        node = ${item}
                     }
                 }
             }

--- a/NodeTypes/Document/Blog/BlogPosting.yaml
+++ b/NodeTypes/Document/Blog/BlogPosting.yaml
@@ -18,6 +18,8 @@
       # No documents below here
       'Neos.Demo:Constraint.Document.SubPage': false
   properties:
+    hiddenInMenu:
+      defaultValue: true
     # Hide title field in inspector as this will be inline editable on this page.
     title:
       ui:

--- a/NodeTypes/Document/Blog/BlogPosting.yaml
+++ b/NodeTypes/Document/Blog/BlogPosting.yaml
@@ -53,3 +53,17 @@
           group: default
       validation:
         Neos.Neos/Validation/NotEmptyValidator: {}
+  references:
+    categories:
+      constraints:
+        nodeTypes:
+          '*': false
+          'Neos.Demo:Document.BlogCategory': true
+      ui:
+        label: i18n
+        reloadIfChanged: true
+        showInCreationDialog: true
+        inspector:
+          group: default
+          editorOptions:
+            nodeTypes: ['Neos.Demo:Document.BlogCategory']

--- a/NodeTypes/Document/Blog/BlogPosting.yaml
+++ b/NodeTypes/Document/Blog/BlogPosting.yaml
@@ -36,6 +36,7 @@
         inspector:
           group: default
     datePublished:
+      scope: nodeAggregate
       type: DateTime
       ui:
         label: i18n

--- a/Resources/Private/Fusion/Presentation/BlogIntro.fusion
+++ b/Resources/Private/Fusion/Presentation/BlogIntro.fusion
@@ -7,23 +7,23 @@ prototype(Neos.Demo:Presentation.BlogIntro) < prototype(Neos.Fusion:Component) {
             title = 'Some blog article'
             abstract = 'Some quick example text for an abstract.'
             imageUri = ''
-            author = 'Neos Team'
-            date = ${Date.now()}
+            metadata = afx`
+                {Date.format('now', 'd.m.Y')} - Neos Team
+            `
         }
     }
 
     title = null
     abstract = null
     imageUri = null
-    author = null
-    date = null
+    metadata = null
 
     renderer = afx`
         <div class="flex flex-wrap justify-center">
             <div class="text-center lg:w-8/12">
                 <Neos.Demo:Presentation.Headline tagName="h1" tagStyle="h1">{props.title}</Neos.Demo:Presentation.Headline>
                 <p>{props.abstract}</p>
-                <p>{Date.format(props.date, 'd.m.Y')} - {props.author}</p>
+                <p @if={props.metadata}>{props.metadata}</p>
             </div>
         </div>
         <div @if={props.imageUri}

--- a/Resources/Private/Translations/de/NodeTypes/Document/BlogCategory.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Document/BlogCategory.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="" product-name="Neos.Demo" source-language="en" target-language="de" datatype="plaintext">
+    <body>
+      <trans-unit id="ui.label" xml:space="preserve">
+        <source>Blog Category</source>
+        <target state="translated">Blog Kategorie</target>
+      </trans-unit>
+      <trans-unit id="properties.image" xml:space="preserve">
+        <source>Image</source>
+            <target state="translated">Bild</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Document/BlogPosting.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Document/BlogPosting.xlf
@@ -6,6 +6,10 @@
         <source>Image</source>
         <target state="translated">Bild</target>
       </trans-unit>
+      <trans-unit id="references.categories" xml:space="preserve">
+        <source>Categories</source>
+            <target state="translated">Kategorien</target>
+      </trans-unit>
       <trans-unit id="ui.label" xml:space="preserve">
         <source>Blog Post</source>
         <target state="translated">Blog-Beitrag</target>

--- a/Resources/Private/Translations/en/NodeTypes/Document/BlogCategory.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Document/BlogCategory.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2"
+    xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file original="" product-name="Neos.Demo" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit id="ui.label" xml:space="preserve">
+                <source>Blog Category</source>
+            </trans-unit>
+            <trans-unit id="properties.image" xml:space="preserve">
+                <source>Image</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Document/BlogPosting.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Document/BlogPosting.xlf
@@ -18,6 +18,9 @@
             <trans-unit id="ui.help.message" xml:space="preserve">
                 <source>Create a new blog post and share your thoughts with the world.</source>
             </trans-unit>
+            <trans-unit id="references.categories" xml:space="preserve">
+                <source>Categories</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
These changes are ported from what we prepared for the Neos Con 2025 Workshop

- Usage of new BackReferences via basic BlogCategory
- Usage of new PropertyScope for Publication Date of blog post for example

The categories will be shown in the menu while all blog post should be `hiddenInMenu: true`

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/be9b8aba-2564-486d-b035-de3725091a03" />


category overview:

<img width="1539" alt="image" src="https://github.com/user-attachments/assets/ad73231b-018a-462b-a0f2-94e6302a34ca" />


blog article with category links:

<img width="1394" alt="image" src="https://github.com/user-attachments/assets/20674bb0-b5df-47e5-b4b5-5a29fe3ed4e0" />


