### PR TITLE
BUGFIX: Resolve issues with CKEditor styles in text nodetype

### DIFF
--- a/Resources/Private/Fusion/Presentation/Text.fusion
+++ b/Resources/Private/Fusion/Presentation/Text.fusion
@@ -3,7 +3,6 @@ prototype(Neos.Demo:Presentation.Text) < prototype(Neos.Fusion:Component) {
     // This is used for the living styleguide (Monocle)
     // Read more about this in the README.md
     @styleguide {
-        container = ${'<div class="prose">' + value + '</div>'}
         props.content = '<h2>Lorem ipsum dolor sit amet,</h2>
             <p>consetetur sadipscing elitr, <strong><em>sed diam</em> nonumy eirmod</strong> tempor <code>invidunt</code> ut <em>labore et dolore</em> magna aliquyam erat, sed diam voluptua.</p>
             <p>At vero <a href="#">eos et accusam et</a> justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
@@ -13,5 +12,9 @@ prototype(Neos.Demo:Presentation.Text) < prototype(Neos.Fusion:Component) {
 
     @if.hasContent = ${this.content}
 
-    renderer = ${props.content}
+    renderer = afx`
+        <div class="prose">
+            {props.content}
+        </div>
+    `
 }


### PR DESCRIPTION
As the text element had no wrap on its own, the editable was augmented with the content element wrapping which caused issues between the Neos Ui styles and classes and the CKEditor classes leading to missing or incorrect element outlines.

Before:

<img width="1812" height="1516" alt="CleanShot 2025-09-30 at 14 34 18@2x" src="https://github.com/user-attachments/assets/9231c290-09df-4d34-9e6a-c89e568aed7a" />
<img width="1816" height="1630" alt="CleanShot 2025-09-30 at 14 33 00@2x" src="https://github.com/user-attachments/assets/43971ef0-765b-46ce-ad4f-872b52f21770" />

After:

<img width="1814" height="1642" alt="CleanShot 2025-09-30 at 14 32 38@2x" src="https://github.com/user-attachments/assets/e974b4f9-4e3f-4e01-83f4-4358612d7b9d" />
<img width="1820" height="1522" alt="CleanShot 2025-09-30 at 14 33 59@2x" src="https://github.com/user-attachments/assets/e7aa1c96-e0a1-4637-852a-fb234ba92200" />
