### PR TITLE
BUGFIX: Fix missing Footer menu item labels

### DIFF
--- a/Resources/Private/Fusion/Integration/Footer.fusion
+++ b/Resources/Private/Fusion/Integration/Footer.fusion
@@ -10,14 +10,8 @@ prototype(Neos.Demo:Integration.Footer) < prototype(Neos.Fusion:Renderer) {
 }
 
 prototype(Neos.Demo:Integration.Footer.Renderer) < prototype(Neos.Demo:Presentation.Footer) {
-    menuItems = Neos.Fusion:Map {
-        items = ${q(site).property('metaNavigationItems')}
-        itemRenderer = Neos.Fusion:DataStructure {
-            label = ${item.label}
-            uri = Neos.Neos:NodeUri {
-                node = ${item}
-            }
-        }
+    menuItems = Neos.Neos:MenuItems {
+        itemCollection = ${q(site).property('metaNavigationItems') || []}
     }
     content = Neos.Neos:ContentCollection {
         @context.node = ${q(site).children('footer').get(0)}


### PR DESCRIPTION
In the Neos Demo there is currently a bug with the rendering of the Footer menu item labels.
On the Homepage it is possible to configure the "Meta navigation items" as references. They are used in the Footer to render a navigation.
However, the property `item.label` is not set, causing it to render links without text.

<img width="1914" height="875" alt="Neos Demo missing footer labels" src="https://github.com/user-attachments/assets/2c5688ab-835a-4812-a23f-60e3c8981d35" />

One solution could be to use this:
```
label = ${q(item).property('title')}
```
since `item` contains the node of the target page.

Another solution would be to use `Neos.Neos:MenuItems` as suggested in this PR.
```
menuItems = Neos.Neos:MenuItems {
    itemCollection = ${q(site).property('metaNavigationItems') || []}
}
```
It falls back to an empty array because I think that in an older Neos version it used to return `null` if there were no references or if the property didn't exist. This would then yield the default behaviour of `Neos.Neos:MenuItems`, rendering the normal page tree as menu items:
```
menuItems = Neos.Neos:MenuItems {
    itemCollection = ${q(site).property('thisPropertyDoesntExist')}
}
```