### PR TITLE
BUGFIX: Add wrapper to basic text element

### DIFF
--- a/Resources/Private/Fusion/Presentation/Text.fusion
+++ b/Resources/Private/Fusion/Presentation/Text.fusion
@@ -13,5 +13,9 @@ prototype(Neos.Demo:Presentation.Text) < prototype(Neos.Fusion:Component) {
 
     @if.hasContent = ${this.content}
 
-    renderer = ${props.content}
+    renderer = afx`
+        <div class="prose">
+            {props.content}
+        </div>
+    `
 }


### PR DESCRIPTION
This resolves some issues when selecting text only elements as the neos wrapping and ckeditor wrapping create a custom tag as the node had none of its own. Some of those issues are resolved with Neos.Ui 9.1, but as best practise we should fix this for 9.0.